### PR TITLE
Use pe-razor-client instead of razor-client

### DIFF
--- a/puppet/modules/razor_client/manifests/init.pp
+++ b/puppet/modules/razor_client/manifests/init.pp
@@ -1,6 +1,6 @@
 class razor_client {
 
-  package { 'razor-client' :
+  package { 'pe-razor-client' :
     ensure   => present,
     provider => pe_gem,
   }


### PR DESCRIPTION
PE has its own client gem, 'pe-razor-client'. Since this Vagrant setup is for
 PE, it should use this instead.
