### PR TITLE
Update enviroment for PE 2015.2.0

### DIFF
--- a/config/pe_build.yaml
+++ b/config/pe_build.yaml
@@ -1,4 +1,4 @@
 ---
 pe_build:
-  version: '3.8.0'
+  version: '2015.2.0'
   download_root: "https://s3.amazonaws.com/pe-builds/released/:version"

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -21,19 +21,11 @@ roles:
       - type: shell
         inline: "echo 'nameserver 8.8.8.8' > /etc/resolv.conf"
       - type: shell
-        inline: "x=`/opt/puppet/bin/puppet config print basemodulepath`;/opt/puppet/bin/puppet config set basemodulepath ${x}:/tmp/puppet/modules"
+        inline: "x=`/opt/puppetlabs/bin/puppet config print basemodulepath`;/opt/puppetlabs/bin/puppet config set basemodulepath ${x}:/tmp/puppet/modules"
       - type: shell
-        inline: '/opt/puppet/bin/puppet module install puppetlabs/stdlib --version 4.4.0'
+        inline: '/opt/puppetlabs/bin/puppet module install puppetlabs/stdlib --version 4.4.0'
       - type: shell
-        inline: '/opt/puppet/bin/puppet module install puppetlabs/pe_gem --version 0.0.1'
-      - type: shell
-        inline: '/bin/cp /tmp/puppet/manifests/site.pp /etc/puppetlabs/puppet/manifests/site.pp'
-      - type: shell
-        inline: '/opt/puppet/bin/puppet apply /tmp/puppet/misc/make_link_to_site_pp.pp'
-      #restart the master for 3.3 and below
-      - type: shell
-        inline: 'service pe-httpd restart'
-      #restart the master for 3.4 and above
+        inline: '/bin/cp /tmp/puppet/manifests/site.pp /etc/puppetlabs/code/environments/production/manifests/site.pp'
       - type: shell
         inline: 'service pe-puppetserver restart'
 
@@ -41,7 +33,7 @@ roles:
     provisioners:
       - type: hosts
       - type: shell
-        inline: 'mkdir -p /var/lib/hiera; cp /vagrant/hierafiles/defaults.yaml /var/lib/hiera/defaults.yaml'
+        inline: 'mkdir -p /etc/puppetlabs/code/environments/production/hieradata/; cp /vagrant/hierafiles/defaults.yaml /etc/puppetlabs/code/environments/production/hieradata/common.yaml'
       - type: pe_bootstrap
         role: :master
 #        version: '3.2.0'

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -23,7 +23,7 @@ roles:
       - type: shell
         inline: "x=`/opt/puppet/bin/puppet config print basemodulepath`;/opt/puppet/bin/puppet config set basemodulepath ${x}:/tmp/puppet/modules"
       - type: shell
-        inline: /opt/puppet/bin/puppet module install puppetlabs/stdlib --version 4.4.0 
+        inline: '/opt/puppet/bin/puppet module install puppetlabs/stdlib --version 4.4.0'
       - type: shell
         inline: '/opt/puppet/bin/puppet module install puppetlabs/pe_gem --version 0.0.1'
       - type: shell
@@ -31,7 +31,7 @@ roles:
       - type: shell
         inline: '/opt/puppet/bin/puppet apply /tmp/puppet/misc/make_link_to_site_pp.pp'
       #restart the master for 3.3 and below
-      - type: shell 
+      - type: shell
         inline: 'service pe-httpd restart'
       #restart the master for 3.4 and above
       - type: shell
@@ -62,9 +62,9 @@ roles:
       - {type: hosts}
       - type: pe_bootstrap
 #        version: '3.2.0'
-        master: 'puppet-master' 
+        master: 'puppet-master'
 
-  centos: 
+  centos:
     provisioners:
       - type: shell
         inline: 'service iptables stop; chkconfig iptables off;'
@@ -75,7 +75,7 @@ roles:
         inline: 'iptables -F'
       - type: shell
         inline: 'iptables --table nat --append POSTROUTING --out-interface eth0 -j MASQUERADE'
-      - type: shell 
+      - type: shell
         inline: 'service iptables save'
       - type: shell
         inline: 'service iptables restart'

--- a/puppet/modules/razor_client/manifests/init.pp
+++ b/puppet/modules/razor_client/manifests/init.pp
@@ -2,17 +2,17 @@ class razor_client {
 
   package { 'pe-razor-client' :
     ensure   => present,
-    provider => pe_gem,
+    provider => puppet_gem,
   }
 
   package { 'json_pure' :
     ensure   => present,
-    provider => pe_gem,
+    provider => puppet_gem,
   }
 
   file { '/usr/bin/razor' :
     ensure  => link,
-    target  => '/opt/puppet/bin/razor',
+    target  => '/opt/puppetlabs/puppet/bin/razor',
     require => Package['pe-razor-client'],
   }
 

--- a/puppet/modules/razor_dnsmasq/manifests/init.pp
+++ b/puppet/modules/razor_dnsmasq/manifests/init.pp
@@ -12,25 +12,25 @@ class razor_dnsmasq {
     require => Package['dnsmasq'],
   }
 
-  file { "${dnsmasq_config_dir}" : 
+  file { "${dnsmasq_config_dir}" :
     ensure => directory,
   }
 
-  file { "${dnsmasq_config_dir}/hosts" : 
+  file { "${dnsmasq_config_dir}/hosts" :
     ensure => file,
     source => 'puppet:///modules/razor_dnsmasq/dnsmasq.d/hosts',
     require => File["${dnsmasq_config_dir}"],
     notify => Service['dnsmasq'],
   }
- 
-  file { "${dnsmasq_config_dir}/razor" : 
+
+  file { "${dnsmasq_config_dir}/razor" :
     ensure => file,
     source => 'puppet:///modules/razor_dnsmasq/dnsmasq.d/razor',
     require => File["${dnsmasq_config_dir}"],
     notify => Service['dnsmasq'],
   }
 
-  file { "${dnsmasq_config_dir}/virtualbox" : 
+  file { "${dnsmasq_config_dir}/virtualbox" :
     ensure => file,
     source => 'puppet:///modules/razor_dnsmasq/dnsmasq.d/virtualbox',
     require => File["${dnsmasq_config_dir}"],
@@ -53,21 +53,21 @@ class razor_dnsmasq {
     ensure => directory,
     before => Service['dnsmasq']
   }
-  
+
   file { '/var/lib/tftpboot/undionly-20140116.kpxe' :
     ensure => file,
     source => 'puppet:///modules/razor_dnsmasq/undionly-20140116.kpxe',
-  }  
+  }
 
   case versioncmp( $::pe_version, '3.7.99') {
-      '1':  { $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'https://razor-server:8151/api/microkernel/bootstrap?nic_max=1&http_port=8150' -O /var/lib/tftpboot/bootstrap.ipxe" }
-      '-1': { $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'http://razor-server:8080/api/microkernel/bootstrap?nic_max=1' -O /var/lib/tftpboot/bootstrap.ipxe" } 
+      '-1': { $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'http://razor-server:8080/api/microkernel/bootstrap?nic_max=1' -O /var/lib/tftpboot/bootstrap.ipxe" }
+      default:  { $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'https://razor-server:8151/api/microkernel/bootstrap?nic_max=1&http_port=8150' -O /var/lib/tftpboot/bootstrap.ipxe" }
   }
 
   exec { 'get bootstrap.ipxe from razor server' :
-    command => $ipxe_dl_cmd, 
-    tries   => 10,
+    command   => $ipxe_dl_cmd,
+    tries     => 10,
     try_sleep => 30,
-    unless  => '/usr/bin/test -s /var/lib/tftpboot/bootstrap.ipxe',
+    unless    => '/usr/bin/test -s /var/lib/tftpboot/bootstrap.ipxe',
   }
 }


### PR DESCRIPTION
This patch updates the environment to work with PE 2015.2.0. 

It breaks backwards compatibility with 3.x

